### PR TITLE
Do gapi action as soon as finger is lifted off screen

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -113,7 +113,7 @@ function App(): JSX.Element {
           key={threadId}
           threadId={threadId}
           actions={threadActions}
-          cardSwipedAway={updateThreadListState}
+          onCardOffScreen={updateThreadListState}
           preventRenderMessages={index > 2}
         />
       );


### PR DESCRIPTION
No need to wait for the card to actually be offscreen to do the network request. This is especially important right now because our spring animation takes an extra 1.5s to finish once the card is offscreen, but even when we fix that, we may as well process the network requestion ASAP.