### PR TITLE
Assorted fixes.

### DIFF
--- a/src/Gapi.tsx
+++ b/src/Gapi.tsx
@@ -259,7 +259,3 @@ export async function modifyMessages(
     await modifyThread(threadId, addLabelIds, removeLabelIds);
   }
 }
-
-export function archiveMessages(messages: Message[]): Promise<void> {
-  return modifyMessages(messages, [], ['INBOX']);
-}

--- a/src/Labels.tsx
+++ b/src/Labels.tsx
@@ -2,9 +2,18 @@ import {defined} from './Base';
 import {createLabel, fetchLabels} from './Gapi';
 
 const TEAMAIL_BASE_LABEL = 'tm';
+const MKTIME_BASE_LABEL = 'mktime';
+const PRIORITY_LABEL_NAME = `${MKTIME_BASE_LABEL}/priority`;
 
 export const LabelName = {
   keep: `${TEAMAIL_BASE_LABEL}/keep`,
+  bookmark: `${PRIORITY_LABEL_NAME}/Bookmark`,
+  pin: `${PRIORITY_LABEL_NAME}/Pin`,
+  emptyDaily: `${PRIORITY_LABEL_NAME}/Empty-daily`,
+  urgent: `${PRIORITY_LABEL_NAME}/Urgent`,
+  backlog: `${PRIORITY_LABEL_NAME}/Backlog`,
+  stuck: `${PRIORITY_LABEL_NAME}/Stuck`,
+  softMute: `${MKTIME_BASE_LABEL}/softmute`,
 };
 
 export class Label {
@@ -46,6 +55,11 @@ export class LabelMap {
       return label;
     }
 
+    // TODO: There's a race here if the label got created in another client
+    // after this client had initially loaded labels. This should realy return
+    // in that case, but instead it throws an error due to receiving a 409 from
+    // the createLabel call with status "ABORTED" and message "Label name exists
+    // or conflicts"
     const parts = labelName.split('/');
 
     let labelSoFar;

--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -42,7 +42,7 @@ export class Message {
   from?: string;
   to?: string;
   cc?: string;
-  date?: string;
+  date?: string | number;
   deliveredTo?: string;
   replyTo?: string;
   sender?: string;
@@ -104,7 +104,9 @@ export class Message {
     }
     // Some messages don't have a date header. Fallback to gmail's internal one.
     if (!this.date) {
-      this.date = this._rawMessage.internalDate;
+      // If this is a string then new Date tries to parse it as such. This ms
+      // since epoch, which new Date takes as a number.
+      this.date = Number(this._rawMessage.internalDate);
     }
   }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -58,7 +58,6 @@ function App(): JSX.Element {
     (async (): Promise<void> => {
       const namesToExclude = Object.values(LabelName).join('" -in:"');
       const query = `in:inbox -in:chats -in:"${namesToExclude}"`;
-      console.log(query);
       const threads = (await fetchThreads(query)).threads;
       if (threads) {
         // TODO: Fetch message data to get the dates so we can sort by date.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,14 +9,9 @@ import {
 } from 'react-native';
 
 import {Card} from './Card';
-import {archiveMessages, fetchThreads, modifyMessages, login} from '../Gapi';
-import {Message} from '../Message';
+import {fetchThreads, login} from '../Gapi';
 import {defined} from '../Base';
 import {LabelName, Labels} from '../Labels';
-export interface ThreadActions {
-  archive: (messages: Message[]) => Promise<void>;
-  keep: (messages: Message[]) => Promise<void>;
-}
 
 interface ThreadsState {
   threads: gapi.client.gmail.Thread[];
@@ -61,8 +56,10 @@ function App(): JSX.Element {
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async (): Promise<void> => {
-      const threads = (await fetchThreads(`in:inbox -in:${LabelName.keep}`))
-        .threads;
+      const namesToExclude = Object.values(LabelName).join('" -in:"');
+      const query = `in:inbox -in:chats -in:"${namesToExclude}"`;
+      console.log(query);
+      const threads = (await fetchThreads(query)).threads;
       if (threads) {
         // TODO: Fetch message data to get the dates so we can sort by date.
         updateThreadListState({threads});
@@ -80,16 +77,6 @@ function App(): JSX.Element {
     })();
   }, []);
 
-  const threadActions: ThreadActions = {
-    archive: (messages: Message[]) => {
-      return archiveMessages(messages);
-    },
-    keep: async (messages: Message[]) => {
-      const keepLabel = await Labels.getOrCreateLabel(LabelName.keep);
-      return modifyMessages(messages, [keepLabel.getId()], []);
-    },
-  };
-
   // TODO: Once we take message fetching out of Card creation, only prerender
   // one card below the most recently swiped card. Until then, render more cards
   // and prevent rendering their messages to avoid getting stalled on slow
@@ -103,7 +90,6 @@ function App(): JSX.Element {
         <Card
           key={threadId}
           threadId={threadId}
-          actions={threadActions}
           onCardOffScreen={updateThreadListState}
           preventRenderMessages={index > 2}
         />


### PR DESCRIPTION
- Exclude chats and mktime priority labels for the in:inbox query
- Change keep to empty daily for now. Also sets the keep label under the hood.
- Fix date parsing when we fallback to the gmail message internalDate.
- Center align button text so Empty daily looks reasonable.
- Stop passing threadActions into Card. It's unnecessary abstraction for the forseeable future.